### PR TITLE
Strip styles that were causing extra horizontal scroll

### DIFF
--- a/src/components/USMap.jsx
+++ b/src/components/USMap.jsx
@@ -24,9 +24,6 @@ const styles = StyleSheet.create({
     }
   },
   map: {
-    marginLeft: '50%',
-    transform: 'translate(-50%, 0)',
-    width: '100%',
     height: 'auto',
     maxHeight: '100%'
   },


### PR DESCRIPTION
Not sure why styles `marginLeft: '50%', transform: 'translate(-50%, 0)', width: '100%'` on map were added, but removing them fixes scroll issue. Size of map seems to be the same (in chrome). If these styles were added to take care of some other issue, let me know and we can figure out another solution.