### PR TITLE
Fix broken sign-up link on about page

### DIFF
--- a/src/components/Signup.jsx
+++ b/src/components/Signup.jsx
@@ -93,7 +93,7 @@ export default class Signup extends React.Component {
           padding: '20px 20px 20px 20px'
         }}
       >
-        <div className={styles.formHeader}>
+        <div id="sign-up" className={styles.formHeader}>
           <span className={styles.bold}>Sign up</span> to receive updates and see how you can help
         </div>
         <BNCForm

--- a/src/containers/Tour.jsx
+++ b/src/containers/Tour.jsx
@@ -178,7 +178,7 @@ class Tour extends React.Component {
       <div className={styles.cantMakeIt}>
         Can't make it to an event?&nbsp;
         <span className={styles.highlight}>
-          <a href='/home' className={styles.link}>Sign up to join the movement!</a>
+          <a href='/home#sign-up' className={styles.link}>Sign up to join the movement!</a>
         </span>
       </div>
     )

--- a/src/static-site/about.html
+++ b/src/static-site/about.html
@@ -41,7 +41,7 @@
      <!-- <div class="block m-y-0 p-y-0 p-x-0 p-t-md text-center"> -->
     <div class="container">
     <h2>Who's proposing this?</h2>
-    <p class="lead">Right now, this is just an idea that some of us Bernie volunteers and former staff have been talking about with each other. We're all busy working for Bernie until he's in the White House. But we're proposing the campaign for a Brand New Congress as something to work on next. Only something as big and worthwhile as this can keep the revolution going&mdash;and it's the only way to give Bernie the ability to make real change from the White House. If you would like updates or to get involved, <a href="index">please sign up</a> and one of us will be in touch.</p>
+    <p class="lead">Right now, this is just an idea that some of us Bernie volunteers and former staff have been talking about with each other. We're all busy working for Bernie until he's in the White House. But we're proposing the campaign for a Brand New Congress as something to work on next. Only something as big and worthwhile as this can keep the revolution going&mdash;and it's the only way to give Bernie the ability to make real change from the White House. If you would like updates or to get involved, <a href="/home#sign-up">please sign up</a> and one of us will be in touch.</p>
     <div class="gallery">
      <div class="row">
 

--- a/src/static-site/home.html
+++ b/src/static-site/home.html
@@ -56,7 +56,7 @@
     <div class="block block-2-content p-y-md p-x height-center">
         <div class="container">
             <div class="row p-t-0">
-                <div class="form-block col-md-6 p-b p-t p-x">
+                <div id="sign-up" class="form-block col-md-6 p-b p-t p-x">
                     <h3><span class="heavy">Please sign up</span> to receive updates and see how you can help:</h3>
                     <!--    Form data is dynamically added via script at bottom of page  -->
 


### PR DESCRIPTION
Fixes #72 

Link directly to the #sign-up form
Also add direct link to form from tour page