### PR TITLE
Add transform to strip spaces in email field of form schema

### DIFF
--- a/src/components/Signup.jsx
+++ b/src/components/Signup.jsx
@@ -73,8 +73,8 @@ export default class Signup extends React.Component {
   }
 
   formSchema = yup.object({
-    email: yup.string().required().email(),
-    fullName: yup.string().required(),
+    email: yup.string().transform((value) => value.replace(/\s/g, '')).required().email(),
+    fullName: yup.string().trim().required(),
     phone: yup.string().required().min(10),
     zip: yup.string().required()
   })


### PR DESCRIPTION
Resolves #124. This is just a convenience to help the people who are accidentally adding spaces when typing an email address on their phone. The submitted email address has spaces removed even if they mistyped.