### PR TITLE
Fixed URLs

### DIFF
--- a/src/static/site/teams.md
+++ b/src/static/site/teams.md
@@ -8,13 +8,13 @@ Right now we are laser focused on putting together our slate of candidates. The 
 
 1. [Join a BNC candidate nomination orientation call](/call) to get a nuanced understanding of the BNC candidate criteria.
 
-2. Search for potential candidates. [Here is a guide with tips] (https://docs.google.com/document/d/1_Aob44aXGpc6OVOxzLNMSW-9_Hs7m5nghKYBGoeuUlE/edit?usp=sharing)
+2. Search for potential candidates. [Here is a guide with tips](https://docs.google.com/document/d/1_Aob44aXGpc6OVOxzLNMSW-9_Hs7m5nghKYBGoeuUlE/edit?usp=sharing)
 
-3. [Submit] (brandnewcongress.org/nominate) those nominations! This really does help!
+3. [Submit](brandnewcongress.org/nominate) those nominations! This really does help!
 
 # Put your skills to work
 
-The revolution needs you! [Tell us about your skills, talents, and interests.] (https://goo.gl/forms/CGeULYdVgKTnW72D2) We'll keep the information you submit on file and when the time and need arises, you will be on our list of people to contact for that project/need. Thanks for offering to pitch in.
+The revolution needs you! [Tell us about your skills, talents, and interests.](https://goo.gl/forms/CGeULYdVgKTnW72D2) We'll keep the information you submit on file and when the time and need arises, you will be on our list of people to contact for that project/need. Thanks for offering to pitch in.
 
 # Organize locally 
 

--- a/src/static/site/teams.md
+++ b/src/static/site/teams.md
@@ -10,7 +10,7 @@ Right now we are laser focused on putting together our slate of candidates. The 
 
 2. Search for potential candidates. [Here is a guide with tips](https://docs.google.com/document/d/1_Aob44aXGpc6OVOxzLNMSW-9_Hs7m5nghKYBGoeuUlE/edit?usp=sharing)
 
-3. [Submit](brandnewcongress.org/nominate) those nominations! This really does help!
+3. [Submit](https://brandnewcongress.org/nominate) those nominations! This really does help!
 
 # Put your skills to work
 


### PR DESCRIPTION
The space between right bracket and left paren may be causing the urls to break on the live site. the markdown is appearing on the live site instead of rendered HTML. I suspect the github markdown renderer is working differently than the live site markdown renderer.